### PR TITLE
:arrow_up: Bump chromatic from 11.20.2 to 11.22.0 in the testing group

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -58,7 +58,7 @@
     "@types/react-dom": "^19.0.1",
     "@vitest/browser": "^2.1.8",
     "autoprefixer": "^10.4.20",
-    "chromatic": "^11.20.2",
+    "chromatic": "^11.22.0",
     "eslint": "^9.17.0",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
       chromatic:
-        specifier: ^11.20.2
-        version: 11.20.2
+        specifier: ^11.22.0
+        version: 11.22.0
       eslint:
         specifier: ^9.17.0
         version: 9.17.0(jiti@1.21.7)
@@ -2237,8 +2237,8 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chromatic@11.20.2:
-    resolution: {integrity: sha512-c+M3HVl5Y60c7ipGTZTyeWzWubRW70YsJ7PPDpO1D735ib8+Lu3yGF90j61pvgkXGngpkTPHZyBw83lcu2JMxA==}
+  chromatic@11.22.0:
+    resolution: {integrity: sha512-u1kAPR9lj9aFzsCp0iWPXBbsKgcxFU7iJO6mFbgNHGVg+YPBqiJMuvgB8EQHdNbHjk5amFnGnIz/Ww8fK3t9Hw==}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
@@ -7499,7 +7499,7 @@ snapshots:
     dependencies:
       readdirp: 4.0.2
 
-  chromatic@11.20.2: {}
+  chromatic@11.22.0: {}
 
   cli-cursor@5.0.0:
     dependencies:


### PR DESCRIPTION
Bumps the testing group with 1 update: [chromatic](https://github.com/chromaui/chromatic-cli).


Updates `chromatic` from 11.20.2 to 11.22.0
- [Release notes](https://github.com/chromaui/chromatic-cli/releases)
- [Changelog](https://github.com/chromaui/chromatic-cli/blob/main/CHANGELOG.md)
- [Commits](https://github.com/chromaui/chromatic-cli/compare/v11.20.2...v11.22.0)

---
updated-dependencies:
- dependency-name: chromatic dependency-type: direct:development update-type: version-update:semver-minor dependency-group: testing ...